### PR TITLE
Fix streaming loop to handle errors and partial data

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,39 +60,54 @@ button:disabled{opacity:0.6;cursor:default;}
     chatLogEl.appendChild(assistantDiv);
     chatLogEl.scrollTop = chatLogEl.scrollHeight;
 
-    const res = await fetch(endpoint, {
-      method:"POST",
-      headers:{"Content-Type":"application/json"},
-      body:JSON.stringify({
-        model,
-        messages: history,
-        stream: true
-      })
-    });
+    try {
+      const res = await fetch(endpoint, {
+        method:"POST",
+        headers:{"Content-Type":"application/json"},
+        body:JSON.stringify({
+          model,
+          messages: history,
+          stream: true
+        })
+      });
+      if(!res.ok) throw new Error("HTTP " + res.status);
 
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder("utf-8");
-    let buffer = "";
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder("utf-8");
+      let buffer = "";
 
-    while(true){
-      const {value, done} = await reader.read();
-      if(done) break;
-      buffer += decoder.decode(value, {stream:true});
-      const lines = buffer.split("\n");
-      buffer = lines.pop();  // last partial line
-      for(const line of lines){
-        if(!line.trim()) continue;
-        const data = JSON.parse(line);
+      while(true){
+        const {value, done} = await reader.read();
+        if(done) break;
+        buffer += decoder.decode(value, {stream:true});
+        const lines = buffer.split("\n");
+        buffer = lines.pop();  // last partial line
+        for(const line of lines){
+          if(!line.trim()) continue;
+          const data = JSON.parse(line);
+          if(data.message && data.message.content){
+            assistantText += data.message.content;
+            assistantDiv.textContent = assistantText;
+            chatLogEl.scrollTop = chatLogEl.scrollHeight;
+          }
+        }
+      }
+
+      if(buffer.trim()){
+        const data = JSON.parse(buffer);
         if(data.message && data.message.content){
           assistantText += data.message.content;
           assistantDiv.textContent = assistantText;
-          chatLogEl.scrollTop = chatLogEl.scrollHeight;
         }
       }
+
+      history.push({role:"assistant", content:assistantText});
+    } catch(err) {
+      assistantDiv.textContent = "[Error] " + err.message;
+    } finally {
+      sendBtn.disabled = false;
+      promptEl.focus();
     }
-    history.push({role:"assistant", content:assistantText});
-    sendBtn.disabled = false;
-    promptEl.focus();
   }
 
   sendBtn.addEventListener("click", sendMessage);


### PR DESCRIPTION
## Summary
- handle HTTP errors and decoding failures in the chat JS
- flush remaining buffer after streaming finishes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841734660d883288f48322688cf6012