### PR TITLE
Render Markdown in chat messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,13 +40,28 @@ button:disabled{opacity:0.6;cursor:default;}
   const promptEl = document.getElementById("prompt");
   const sendBtn = document.getElementById("sendBtn");
 
+  /** Convert basic markdown to HTML */
+  function renderMarkdown(text){
+    const escaped = text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+    return escaped
+      .replace(/```([\s\S]*?)```/g, '<pre><code>$1</code></pre>')
+      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+      .replace(/(\*|_)([^\*_]+)\1/g, '<em>$2</em>')
+      .replace(/`([^`]+)`/g, '<code>$1</code>')
+      .replace(/\[([^\]]+)\]\(([^\)]+)\)/g, '<a href="$2" target="_blank">$1</a>')
+      .replace(/\n/g, '<br>');
+  }
+
   /** Store conversation history */
   const history = [];
 
   function addMessage(text, role){
     const div = document.createElement("div");
     div.className = "message " + (role === "user" ? "user" : "assistant");
-    div.textContent = text;
+    div.innerHTML = renderMarkdown(text);
     chatLogEl.appendChild(div);
     chatLogEl.scrollTop = chatLogEl.scrollHeight;
   }
@@ -94,7 +109,7 @@ button:disabled{opacity:0.6;cursor:default;}
           const data = JSON.parse(line);
           if(data.message && data.message.content){
             assistantText += data.message.content;
-            assistantDiv.textContent = assistantText;
+            assistantDiv.innerHTML = renderMarkdown(assistantText);
             chatLogEl.scrollTop = chatLogEl.scrollHeight;
           }
         }
@@ -104,7 +119,7 @@ button:disabled{opacity:0.6;cursor:default;}
         const data = JSON.parse(buffer);
         if(data.message && data.message.content){
           assistantText += data.message.content;
-          assistantDiv.textContent = assistantText;
+          assistantDiv.innerHTML = renderMarkdown(assistantText);
         }
       }
 


### PR DESCRIPTION
## Summary
- add a small Markdown renderer
- use it when adding user and assistant messages so formatting shows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684177b4c23c83289e7db562c12cc631