### PR TITLE
Improve input bar transparency

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <style>
 body{font-family:system-ui, sans-serif;background:#f6f6f6;margin:0;display:flex;flex-direction:column;height:100vh;}
 header{background:linear-gradient(135deg,#0d6efd,#6610f2);color:#fff;padding:16px 24px;font-size:1.3rem;font-weight:bold;position:sticky;top:0;z-index:1;box-shadow:0 2px 6px rgba(0,0,0,0.08);text-shadow:0 1px 2px rgba(0,0,0,0.2);}
-#chatWrapper{flex:1;position:relative;overflow:hidden;display:flex;}
+#chatWrapper{flex:1;position:relative;overflow:hidden;display:flex;flex-direction:column;}
 #chatLog{flex:1;overflow-y:auto;padding:16px;display:flex;flex-direction:column;gap:12px;}
 @keyframes auroraMove{0%{background-position:0% 50%;filter:hue-rotate(0deg);}50%{background-position:100% 50%;filter:hue-rotate(60deg);}100%{background-position:0% 50%;filter:hue-rotate(0deg);}}
 #chatWrapper::before{content:"";position:absolute;inset:0;background:linear-gradient(120deg,rgba(0,128,255,0.7),rgba(128,0,128,0.7),rgba(0,255,128,0.7));background-size:200% 200%;animation:auroraMove 20s ease-in-out infinite;pointer-events:none;opacity:0.6;filter:blur(30px);}
@@ -21,7 +21,7 @@ header{background:linear-gradient(135deg,#0d6efd,#6610f2);color:#fff;padding:16p
   display:flex;
   padding:12px 16px;
   gap:12px;
-  background:rgba(255,255,255,0.8);
+  background:rgba(255,255,255,0.5);
   backdrop-filter:blur(6px);
   border-top:1px solid #ddd;
   box-shadow:0 -2px 4px rgba(0,0,0,0.05);
@@ -60,8 +60,7 @@ button:disabled{opacity:0.6;cursor:default;}
 <header>🦙 Ollama Chat (Local)</header>
 <div id="chatWrapper">
   <main id="chatLog"></main>
-</div>
-<div id="inputBar">
+  <div id="inputBar">
 <select id="modelSelect">
   <option value="gemma3:1b-it-qat">gemma3:1b-it-qat</option>
   <option value="llama3">llama3</option>
@@ -69,6 +68,7 @@ button:disabled{opacity:0.6;cursor:default;}
 </select>
 <textarea id="prompt" placeholder="メッセージを入力..." rows="2"></textarea>
 <button id="sendBtn">送信</button>
+</div>
 </div>
 
 <script>


### PR DESCRIPTION
## Summary
- show aurora animation under input area by making the bar semi-transparent
- move the input bar inside the wrapper so the aurora overlay covers it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68424b4589908328bcae3d433e53640b