### PR TITLE
Fix speak button overlapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ header{background:linear-gradient(135deg,#0d6efd,#6610f2);color:#fff;padding:16p
 #chatWrapper::after{content:"";position:absolute;inset:0;background:linear-gradient(60deg,rgba(255,255,255,0.3),rgba(0,0,0,0.1),rgba(255,255,255,0.3));background-size:200% 200%;animation:auroraMove 25s ease-in-out infinite;pointer-events:none;mix-blend-mode:overlay;opacity:0.4;filter:blur(20px);}
 .message{max-width:75%;padding:12px 16px;border-radius:8px;white-space:pre-wrap;line-height:1.4;position:relative;}
 .user{align-self:flex-end;background:#0d6efd;color:#fff;border-bottom-right-radius:0;margin-right:2.2em;}
-.assistant{align-self:flex-start;background:#e0e0e0;border-bottom-left-radius:0;margin-left:2.2em;}
+.assistant{align-self:flex-start;background:#e0e0e0;border-bottom-left-radius:0;margin-left:2.2em;padding-right:2em;}
 .message.user::after,.message.assistant::before{position:absolute;top:50%;transform:translateY(-50%);font-size:1.4rem;}
 .message.user::after{content:"🙂";right:-2em;}
 .message.assistant::before{content:"🦙";left:-2em;}
@@ -158,6 +158,7 @@ button:disabled{opacity:0.6;cursor:default;}
   assistantDiv.appendChild(contentDiv);
   const speakBtn = createSpeakButton(() => assistantText);
   speakBtn.disabled = true;
+  speakBtn.style.display = "none";
   assistantDiv.appendChild(speakBtn);
   chatLogEl.appendChild(assistantDiv);
     if(autoScroll){
@@ -209,6 +210,7 @@ button:disabled{opacity:0.6;cursor:default;}
 
       history.push({role:"assistant", content:assistantText});
       speakBtn.disabled = false;
+      speakBtn.style.display = "inline";
     } catch(err) {
       contentDiv.textContent = "[Error] " + err.message;
     } finally {


### PR DESCRIPTION
## Summary
- avoid speak button covering text by adding right padding to assistant bubble
- hide the button until the streaming answer is finished

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684279b3bdfc83289fb6bba7a5ef731c